### PR TITLE
Allow stdin reading too: use `-` as filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,9 @@ func main() {
 func stat(filenames ...string) []error {
 	var errs []error
 	for _, filename := range filenames {
+		if filename == "-" {
+			continue
+		}
 		_, err := os.Stat(filename)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("cannot find file: %v. Does it exist?", filename))
@@ -69,7 +72,13 @@ func stat(filenames ...string) []error {
 }
 
 func unmarshal(filename string) (interface{}, error) {
-	contents, err := ioutil.ReadFile(filename)
+	var contents []byte
+	var err error
+	if filename == "-" {
+		contents, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		contents, err = ioutil.ReadFile(filename)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[Dash is commonly used](https://unix.stackexchange.com/a/16364) to represent stdin.

Can be handy, for example to compare files that only exist in git with actual files.